### PR TITLE
🐞 fix(loadData):

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -42,8 +42,6 @@ chrome.runtime.onMessage.addListener(async function (
   sender,
   sendResponse
 ) {
-  console.log('listener started');
-
   if (message.action === 'saveJob') {
     response = await saveJob(message.formData);
     sendResponse(response);
@@ -68,8 +66,8 @@ export async function initializeOauth() {
 
 export async function saveJob(formData) {
   const oauth = await initializeOauth();
-  console.log('saving job');
-  console.log(oauth);
+  // console.log('saving job');
+  // console.log(oauth);
 
   const response = await oauth.appendValues(formData);
   return response;

--- a/src/inject.js
+++ b/src/inject.js
@@ -97,21 +97,18 @@ export function parseUrl(url) {
 
 let autoSave = false;
 let savedApplication = false;
-let pageMap;
 let observer;
 
 // Add a listener to listen for the 'loadData' action.
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   if (request.action === 'loadData') {
-    if (!pageMap) {
-      const pageUrl = window.location.href;
+    const pageUrl = window.location.href;
 
-      pageMap = parseUrl(pageUrl);
-    }
+    const pageMap = parseUrl(pageUrl);
     // Store data in Chrome's local storage and send response
-    chrome.storage.local.set(pageMap, function () {
-      sendResponse(pageMap);
-    });
+
+    console.log('loadData:', pageMap);
+    sendResponse(pageMap);
 
     return true; // Indicates that the response is asynchronous
   }

--- a/src/popup/jobForm.js
+++ b/src/popup/jobForm.js
@@ -60,7 +60,7 @@ export default class JobForm {
     saveButton.textContent = 'Submitting...';
 
     const oauth = await this.getOauth();
-    console.log(oauth);
+    // console.log(oauth);
 
     // submit the form data to Google Apps Script
     oauth


### PR DESCRIPTION
Attempting to cache the previously loaded job details was persisting across content changes. I wanted this to limiting scraping calls, but this didn't allow for updating the page data.

Additionally, commented out many console.log calls in order to clean up the log.